### PR TITLE
Add initial UI skeleton and progress log

### DIFF
--- a/ClubRoomCreator.as
+++ b/ClubRoomCreator.as
@@ -1,14 +1,34 @@
 // Global flag to track if our plugin's window should be open or closed
 bool windowOpen = false;
 
+// Entry point called when the plugin loads
+void Main() {
+    // Request authentication tokens for the required Nadeo services
+    NadeoServices::AddAudience("NadeoLiveServices");
+    NadeoServices::AddAudience("NadeoServices");
+    // Wait until authentication is available
+    while (!NadeoServices::IsAuthenticated("NadeoLiveServices")
+        || !NadeoServices::IsAuthenticated("NadeoServices")) {
+        yield();
+    }
+}
+
 // This function is called by Openplanet to draw items in its "Plugins" menu
 void RenderMenu() {
     // Add a menu item labeled "Club Room Creator"
     // The "" means no specific hotkey is assigned yet
     // 'windowOpen' is passed by reference, making it a checkable menu item
     if (UI::MenuItem("Club Room Creator", "", windowOpen)) {
-        // If the item is clicked, UI::MenuItem returns true.
-        // We then toggle the 'windowOpen' state.
+        // Toggle the window when the menu item is clicked
         windowOpen = !windowOpen;
     }
+}
+
+// Draw the plugin's main window
+void Render() {
+    if (!windowOpen) return;
+    // Simple placeholder window until further UI is implemented
+    UI::Begin("Club Room Creator", windowOpen, UI::WindowFlags::AlwaysAutoResize);
+    UI::Text("Plugin setup complete. Further UI will be added here.");
+    UI::End();
 }

--- a/Current_Progress.md
+++ b/Current_Progress.md
@@ -1,0 +1,23 @@
+# Club Room Creator Development Progress
+
+This document tracks progress on developing the Club Room Creator Openplanet plugin.
+It will be updated as new features are implemented following the steps outlined in
+`PluginDevDoc.md`.
+
+## Initial Setup
+- Repository initialized with a minimal plugin skeleton.
+- `info.toml` contains basic metadata for the plugin.
+- `ClubRoomCreator.as` defined `RenderMenu()` for a simple menu entry.
+
+## Progress Made
+- Added `Main()` to request authentication tokens from `NadeoServices`.
+- Implemented a basic `Render()` window that displays a placeholder message.
+- Updated `info.toml` with a dependency on `NadeoServices`.
+
+## Next Steps
+1. Expand the UI in `Render()` to allow setting room name and game mode.
+2. Implement track selection features (search, random selection, local map listing).
+3. Add functions to create the room via Nadeo Live Services API.
+4. Document setup instructions for local development (Openplanet installation, enabling Developer mode, using pnpm for any build steps).
+
+Further progress will be documented in this file as the plugin evolves.

--- a/info.toml
+++ b/info.toml
@@ -3,3 +3,7 @@ name = "Club Room Creator"
 author = "isutty5"
 version = "0.1.0"
 description = "A plugin to create and configure Trackmania Club Rooms."
+
+[dependencies]
+# Ensure Nadeo services are available for API calls
+NadeoServices = "*"


### PR DESCRIPTION
## Summary
- implement `Main` authentication routine
- show placeholder window in `Render`
- reference `NadeoServices` dependency
- add `Current_Progress.md` with progress notes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_683b415f087c832682c958c5aeb52f16